### PR TITLE
Updated link to zircon source to within fuchsia repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 The Fuchsia zircon repository is no longer being mirrored to GitHub.
-See https://fuchsia.googlesource.com/zircon.
+See https://fuchsia.googlesource.com/fuchsia/+/refs/heads/master/zircon/.


### PR DESCRIPTION
This confused me for a while, because I was met with an unapologetic "Login to Google" screen after clicking the link, instead of a 404. As far as I see the repository has been merged into the fuchsia repository.

This PR fixes the link. Perhaps this repository on Github should simply be deleted.